### PR TITLE
Correct five minor typos in notebooks

### DIFF
--- a/notebooks/01a-instructor-probability-simulation.ipynb
+++ b/notebooks/01a-instructor-probability-simulation.ipynb
@@ -60,10 +60,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -191,7 +191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -234,7 +234,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]

--- a/notebooks/01a-student-probability-simulation.ipynb
+++ b/notebooks/01a-student-probability-simulation.ipynb
@@ -60,10 +60,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]

--- a/notebooks/01b-instructor-joint-conditional-probability.ipynb
+++ b/notebooks/01b-instructor-joint-conditional-probability.ipynb
@@ -273,7 +273,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {

--- a/notebooks/01b-student-joint-conditional-probability.ipynb
+++ b/notebooks/01b-student-joint-conditional-probability.ipynb
@@ -209,7 +209,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {

--- a/notebooks/ODSC-East-2020-04-14/01-Instructor-Probability_a_simulated_introduction.ipynb
+++ b/notebooks/ODSC-East-2020-04-14/01-Instructor-Probability_a_simulated_introduction.ipynb
@@ -62,10 +62,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -189,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -232,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]
@@ -1430,7 +1430,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {
@@ -1546,7 +1546,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Question:** Suppose that a test for using a particular drug has 99% sensitivy (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
+    "**Question:** Suppose that a test for using a particular drug has 99% sensitivity (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
     "\n",
     "**If we can answer this, it will be really cool as it shows how we can move from knowing $P(+|user)$ to $P(user|+)$, a MVP for being able to move from $P(data|model)$ to $P(model|data)$.**"
    ]

--- a/notebooks/ODSC-East-2020-04-14/01-Student-Probability_a_simulated_introduction.ipynb
+++ b/notebooks/ODSC-East-2020-04-14/01-Student-Probability_a_simulated_introduction.ipynb
@@ -62,10 +62,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]
@@ -1072,7 +1072,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {
@@ -1155,7 +1155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Question:** Suppose that a test for using a particular drug has 99% sensitivy (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
+    "**Question:** Suppose that a test for using a particular drug has 99% sensitivity (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
     "\n",
     "**If we can answer this, it will be really cool as it shows how we can move from knowing $P(+|user)$ to $P(user|+)$, a MVP for being able to move from $P(data|model)$ to $P(model|data)$.**"
    ]

--- a/notebooks/ODSC-East-2020-04-14/02-Instructor-Parameter_estimation_hypothesis_testing.ipynb
+++ b/notebooks/ODSC-East-2020-04-14/02-Instructor-Parameter_estimation_hypothesis_testing.ipynb
@@ -488,7 +488,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To specify the full probabilty model, you need\n",
+    "To specify the full probability model, you need\n",
     "- a likelihood function for the data &\n",
     "- priors for all unknowns.\n",
     "\n",

--- a/notebooks/ODSC-East-2020-04-14/02-Student-Parameter_estimation_hypothesis_testing.ipynb
+++ b/notebooks/ODSC-East-2020-04-14/02-Student-Parameter_estimation_hypothesis_testing.ipynb
@@ -407,7 +407,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To specify the full probabilty model, you need\n",
+    "To specify the full probability model, you need\n",
     "- a likelihood function for the data &\n",
     "- priors for all unknowns.\n",
     "\n",

--- a/notebooks/SciPy-2020/01-Instructor-Probability_a_simulated_introduction.ipynb
+++ b/notebooks/SciPy-2020/01-Instructor-Probability_a_simulated_introduction.ipynb
@@ -62,10 +62,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -189,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -232,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]
@@ -1430,7 +1430,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {
@@ -1546,7 +1546,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Question:** Suppose that a test for using a particular drug has 99% sensitivy (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
+    "**Question:** Suppose that a test for using a particular drug has 99% sensitivity (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
     "\n",
     "**If we can answer this, it will be really cool as it shows how we can move from knowing $P(+|user)$ to $P(user|+)$, a MVP for being able to move from $P(data|model)$ to $P(model|data)$.**"
    ]

--- a/notebooks/SciPy-2020/01-Student-Probability_a_simulated_introduction.ipynb
+++ b/notebooks/SciPy-2020/01-Student-Probability_a_simulated_introduction.ipynb
@@ -62,10 +62,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]
@@ -1072,7 +1072,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {
@@ -1155,7 +1155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Question:** Suppose that a test for using a particular drug has 99% sensitivy (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
+    "**Question:** Suppose that a test for using a particular drug has 99% sensitivity (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
     "\n",
     "**If we can answer this, it will be really cool as it shows how we can move from knowing $P(+|user)$ to $P(user|+)$, a MVP for being able to move from $P(data|model)$ to $P(model|data)$.**"
    ]

--- a/notebooks/SciPy-2020/02-Instructor-Parameter_estimation_hypothesis_testing.ipynb
+++ b/notebooks/SciPy-2020/02-Instructor-Parameter_estimation_hypothesis_testing.ipynb
@@ -488,7 +488,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To specify the full probabilty model, you need\n",
+    "To specify the full probability model, you need\n",
     "- a likelihood function for the data &\n",
     "- priors for all unknowns.\n",
     "\n",

--- a/notebooks/SciPy-2020/02-Student-Parameter_estimation_hypothesis_testing.ipynb
+++ b/notebooks/SciPy-2020/02-Student-Parameter_estimation_hypothesis_testing.ipynb
@@ -407,7 +407,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To specify the full probabilty model, you need\n",
+    "To specify the full probability model, you need\n",
     "- a likelihood function for the data &\n",
     "- priors for all unknowns.\n",
     "\n",

--- a/notebooks/URGsADS-NYC-2020-02-19/01-Instructor-Probability_a_simulated_introduction.ipynb
+++ b/notebooks/URGsADS-NYC-2020-02-19/01-Instructor-Probability_a_simulated_introduction.ipynb
@@ -62,10 +62,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -189,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -232,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]
@@ -1430,7 +1430,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {
@@ -1546,7 +1546,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Question:** Suppose that a test for using a particular drug has 99% sensitivy (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
+    "**Question:** Suppose that a test for using a particular drug has 99% sensitivity (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
     "\n",
     "**If we can answer this, it will be really cool as it shows how we can move from knowing $P(+|user)$ to $P(user|+)$, a MVP for being able to move from $P(data|model)$ to $P(model|data)$.**"
    ]

--- a/notebooks/URGsADS-NYC-2020-02-19/01-Student-Probability_a_simulated_introduction.ipynb
+++ b/notebooks/URGsADS-NYC-2020-02-19/01-Student-Probability_a_simulated_introduction.ipynb
@@ -62,10 +62,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]
@@ -1072,7 +1072,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {
@@ -1155,7 +1155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Question:** Suppose that a test for using a particular drug has 99% sensitivy (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
+    "**Question:** Suppose that a test for using a particular drug has 99% sensitivity (true positive rate) and 99% specificity (true negative rate), that is, a 1% false positive rate and 1% false negative rate. Suppose that 0.5% (5 in 1,000) of people are users of the drug. What is the probability that a randomly selected individual with a positive test is a drug user?\n",
     "\n",
     "**If we can answer this, it will be really cool as it shows how we can move from knowing $P(+|user)$ to $P(user|+)$, a MVP for being able to move from $P(data|model)$ to $P(model|data)$.**"
    ]

--- a/notebooks/URGsADS-NYC-2020-02-19/02-Instructor-Parameter_estimation_hypothesis_testing.ipynb
+++ b/notebooks/URGsADS-NYC-2020-02-19/02-Instructor-Parameter_estimation_hypothesis_testing.ipynb
@@ -488,7 +488,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To specify the full probabilty model, you need\n",
+    "To specify the full probability model, you need\n",
     "- a likelihood function for the data &\n",
     "- priors for all unknowns.\n",
     "\n",

--- a/notebooks/URGsADS-NYC-2020-02-19/02-Student-Parameter_estimation_hypothesis_testing.ipynb
+++ b/notebooks/URGsADS-NYC-2020-02-19/02-Student-Parameter_estimation_hypothesis_testing.ipynb
@@ -407,7 +407,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To specify the full probabilty model, you need\n",
+    "To specify the full probability model, you need\n",
     "- a likelihood function for the data &\n",
     "- priors for all unknowns.\n",
     "\n",

--- a/notebooks/archive/01-Instructor-Probability_a_simulated_introduction.ipynb
+++ b/notebooks/archive/01-Instructor-Probability_a_simulated_introduction.ipynb
@@ -62,10 +62,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -191,7 +191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -234,7 +234,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]
@@ -1452,7 +1452,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {

--- a/notebooks/archive/01-Student-Probability_a_simulated_introduction.ipynb
+++ b/notebooks/archive/01-Student-Probability_a_simulated_introduction.ipynb
@@ -62,10 +62,10 @@
    "source": [
     "What type of random phenomena are we talking about here? One example is:\n",
     "\n",
-    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probabilty of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
+    "- Knowing that a website has a click-through rate (CTR) of 10%, we can calculate the probability of having 10 people, 9 people, 8 people ... and so on click through, upon drawing 10 people randomly from the population;\n",
     "- But given the data of how many people click through, how can we calculate the CTR? And how certain can we be of this CTR? Or how likely is a particular CTR?\n",
     "\n",
-    "Science mostly asks questions of the second form above & Bayesian thinking provides a wondereful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
+    "Science mostly asks questions of the second form above & Bayesian thinking provides a wonderful framework for answering such questions. Essentially Bayes' Theorem gives us a way of moving from the probability of the data given the model (written as $P(data|model)$) to the probability of the model given the data ($P(model|data)$).\n",
     "\n",
     "We'll first explore questions of the 1st type using simulation: knowing the model, what is the probability of seeing certain data?"
    ]
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probabilty_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
+    "**Note:** Although, in the above, we have described _probability_ in two ways, we have not described it mathematically. We're not going to do so rigorously here, but we will say that _probability_ defines a function from the space of possibilities (in the above, the interval $[0,1]$) that describes how likely it is to get a particular point or region in that space. Mike Betancourt has an elegant [Introduction to Probability Theory (For Scientists and Engineers)](https://betanalpha.github.io/assets/case_studies/probability_theory.html) that I can recommend."
    ]
   },
   {
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "_Discussion point_: This model is know as the bias coin flip. \n",
+    "_Discussion point_: This model is known as the bias coin flip. \n",
     "- Can you see why?\n",
     "- Can it be used to model other phenomena?"
    ]
@@ -1072,7 +1072,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch of of species 'fortis'?\""
+    "Now that we have a grasp on joint probabilities, lets consider conditional probabilities, that is, the probability of some $A$, knowing that some other $B$ is true. We use the notation $P(A|B)$ to denote this. For example, you can ask the question \"What is the probability of a finch beak having depth $<10$, knowing that the finch is of species 'fortis'?\""
    ]
   },
   {

--- a/notebooks/archive/02-Instructor-Parameter_estimation_hypothesis_testing.ipynb
+++ b/notebooks/archive/02-Instructor-Parameter_estimation_hypothesis_testing.ipynb
@@ -492,7 +492,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To specify the full probabilty model, you need\n",
+    "To specify the full probability model, you need\n",
     "- a likelihood function for the data &\n",
     "- priors for all unknowns.\n",
     "\n",

--- a/notebooks/archive/02-Student-Parameter_estimation_hypothesis_testing.ipynb
+++ b/notebooks/archive/02-Student-Parameter_estimation_hypothesis_testing.ipynb
@@ -407,7 +407,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To specify the full probabilty model, you need\n",
+    "To specify the full probability model, you need\n",
     "- a likelihood function for the data &\n",
     "- priors for all unknowns.\n",
     "\n",


### PR DESCRIPTION
While working through the notebooks today at SciPy2020 I found the following small corrections due to an excess of copy editing in a past life. Feel free to incorporate at your discretion. Thanks for the great tutorial session!

Edits made using the following bash commands
- `find . -name "*.ipynb" -exec sed -i '' s/wondereful/wonderful/g {} +`
- `find . -name "*.ipynb" -exec sed -i '' s/probabilty/probability/g {} +`
- `find . -name "*.ipynb" -exec sed -i '' s/sensitivy/sensitivity/g {} +`
- `find . -name "*.ipynb" -exec sed -i "" s/'of of'/'is of'/g {} +`
- `find . -name "*.ipynb" -exec sed -i "" s/'is know as'/'is known as'/g {} +`