### PR TITLE
MNT: Add symbolic link to environment.yml for user clarity

### DIFF
--- a/.azure-pipelines/linux.yml
+++ b/.azure-pipelines/linux.yml
@@ -19,7 +19,7 @@ steps:
 
 - script: |
     # Install Python, py.test, and required packages.
-    conda env create -f binder/environment.yml
+    conda env create -f environment.yml
     source activate bayesian-modelling-tutorial
     conda install -y python=$(python.version)
     python -m ipykernel install --user --name bayesian-modelling-tutorial

--- a/.azure-pipelines/macos.yml
+++ b/.azure-pipelines/macos.yml
@@ -15,7 +15,7 @@ steps:
 
 # - script: |
 #     # Install Python, py.test, and required packages.
-#     conda env create -f binder/environment.yml
+#     conda env create -f environment.yml
 #     source activate bayesian-modelling-tutorial
 #     conda install -y python=$(python.version)
 #     python -m ipykernel install --user --name bayesian-modelling-tutorial

--- a/.azure-pipelines/templates/setup-script-nix.yml
+++ b/.azure-pipelines/templates/setup-script-nix.yml
@@ -1,6 +1,6 @@
 steps:
 - script: |
-    conda env create -f binder/environment.yml
+    conda env create -f environment.yml
     source activate bayesian-modelling-tutorial
     conda install -y python=$(python.version)
     python -m ipykernel install --user --name bayesian-modelling-tutorial

--- a/.azure-pipelines/templates/setup-script-win.yml
+++ b/.azure-pipelines/templates/setup-script-win.yml
@@ -1,6 +1,6 @@
 steps:
 - script: |
-    conda env create -f binder/environment.yml
+    conda env create -f environment.yml
     activate bayesian-modelling-tutorial
     conda install -y python=$(python.version)
     python -m ipykernel install --user --name bayesian-modelling-tutorial

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,7 @@ ARG USER_GID=$USER_UID
 
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
-COPY binder/environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - conda info -a
 
   # Install Python, py.test, and required packages.
-  - conda env create -f binder/environment.yml
+  - conda env create -f environment.yml
   - source activate bayesian-modelling-tutorial
   # This guarantees that the Python version is matrixed.
   - conda install python=$PYTHON_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM continuumio/miniconda3
 RUN apt-get install build-essential -y
 
 # Install environment
-COPY ./binder/environment.yml /environment.yml
+COPY ./environment.yml /environment.yml
 RUN conda env create -f /environment.yml
 RUN rm /environment.yml
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ to **install all the necessary packages**
 from the provided `environment.yml` file.
 
 ```bash
-conda env create -f binder/environment.yml
+conda env create -f environment.yml
 ```
 
 To **activate the environment**, use the `conda activate` command.
@@ -72,7 +72,7 @@ source activate bayesian-modelling-tutorial
 To **update the environment** based on the `environment.yml` specification file, use the `conda update` command.
 
 ```bash
-conda env update -f binder/environment.yml
+conda env update -f environment.yml
 ```
 
 ### 3b. `pip` users
@@ -93,7 +93,7 @@ If you don't want to mess around with dev-ops, click the following badge to get 
 
 ### 4a. Open your Jupyter notebook
 
-1. You will have to install a new IPython kernelspec if you created a new conda environment with `binder/environment.yml`.
+1. You will have to install a new IPython kernelspec if you created a new conda environment with `environment.yml`.
 
     python -m ipykernel install --user --name bayesian-modelling-tutorial --display-name "Python (bayesian-modelling-tutorial)"
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,1 @@
+binder/environment.yml


### PR DESCRIPTION
This PR partially reverts things I did in PR #85. To make it easier for users who are not used to binder but maybe used to typical Conda workflows, add a symbolic link from `binder/environment.yml` to `environment.yml` in the top level of the repository. Additionally, change all instances of `binder/environment.yml` to `environment.yml` (that is, run

```console
git grep --name-only "binder/environment.yml" | xargs sed -i 's|binder/environment.yml|environment.yml|g'
```
).

This does not fully revert the work of PR #85 though, as Binder will always look for config files under the `binder/` directory in a repository if the directory exists. So this is more of a way to keep Binder config clear but also make things easier/clearer for users.

For an example of this behavior, c.f. https://github.com/gradhep/differentiable-analysis-examples/pull/1.